### PR TITLE
Fix typo in Javadoc comment - *no code change*

### DIFF
--- a/src/main/java/io/ebean/annotation/DbDefault.java
+++ b/src/main/java/io/ebean/annotation/DbDefault.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to specify a default value for DDL-generation &amp; Migration.
- * This annotation is <b>EXPERMIENTAL</b> and may change.
+ * This annotation is <b>EXPERIMENTAL</b> and may change.
  * 
  * @author Roland Praml, FOCONIS AG
  */

--- a/src/main/java/io/ebean/annotation/DbMigration.java
+++ b/src/main/java/io/ebean/annotation/DbMigration.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to specify details for DDL &amp; Migration-generation. (e.g. defaults/renames/...)
- * This annotation is <b>EXPERMIENTAL</b> and may change.
+ * This annotation is <b>EXPERIMENTAL</b> and may change.
  *
  * @author Roland Praml, FOCONIS AG
  */


### PR DESCRIPTION
EXPERMIENTAL -> EXPERIMENTAL in Javadoc section of DbDefault and DbMigration